### PR TITLE
[PHP8.4] Deprecate implicitly nullable parameter types

### DIFF
--- a/src/CveService.php
+++ b/src/CveService.php
@@ -48,7 +48,7 @@ final class CveService implements CveServiceInterface
      * @param   Registry|null  $options  The options
      * @param   Http|null      $client   The HTTP client to use for communication.
      */
-    public function __construct(Registry $options = null, Http $client = null)
+    public function __construct(?Registry $options = null, ?Http $client = null)
     {
         $this->options = $options ?: new Registry();
 


### PR DESCRIPTION
### Summary of Changes

updates for [Deprecate implicitly nullable parameter types](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types)

### Testing Instructions

code review

### Documentation Changes Required

no